### PR TITLE
feat: added vimeo transparent URL param

### DIFF
--- a/src/providers/vimeo.js
+++ b/src/providers/vimeo.js
@@ -13,7 +13,7 @@ export default function Vimeo(props) {
   const [frameId] = useState('vimeo-' + Math.random())
   const splitUrl = href.split('/')
   const videoId = splitUrl[splitUrl.length - 1]
-  const url = `${EMBED_PROVIDER_URL}${videoId}`
+  const url = `${EMBED_PROVIDER_URL}${videoId}?transparent=0`
 
   return (
     <iframe


### PR DESCRIPTION
This fixes the aspect ratio to mimic what the current Youtube provider has. It still doesn't expand the base image to enlarge to the entire frame. This is just how Vimeo works, if one wanted to they could override the Vimeo iFrame styles to enlarge the image.